### PR TITLE
add default clone prefix if not set

### DIFF
--- a/importer-script/terraform-importer.py
+++ b/importer-script/terraform-importer.py
@@ -65,6 +65,9 @@ if not ARGS.ct_api_key:
     else:
         sys.exit("Did not find a cloudtamer API key supplied via CLI argument or environment variable (CLOUDTAMERIO_APIKEY or CT_API_KEY).")
 
+if not ARGS.clone_prefix:
+    ARGS.clone_prefix = ""
+
 # validate flags related to cloning
 if ARGS.clone_system_managed:
 


### PR DESCRIPTION
avoids an error where this arg is ref'd in the case that it wasn't supplied