### PR TITLE
:recycle: Make `created_by_user_id` an optional field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - Support creating, updating, and deleting resources for: Azure Role Definitions.
 - Support adding and removing Azure Role Definitions on Project and OU Cloud Rules.
 
+### Changed
+- The 'created_by_user_id' field for Compliance Checks is now optional. This field will default to the requesting user's ID if not specified.
+
 ## [0.2.0] - 2021-11-19
 ### Added
 - Support creating, updating, and deleting resources for: user groups.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,6 @@ output "template_id" {
 # Create an external compliance check.
 resource "cloudtamerio_compliance_check" "c1" {
   name                     = "sample-resource"
-  created_by_user_id       = 1
   cloud_provider_id        = 1
   compliance_check_type_id = 1
   owner_users { id = 1 }

--- a/cloudtamerio/resource_compliance_check.go
+++ b/cloudtamerio/resource_compliance_check.go
@@ -51,9 +51,10 @@ func resourceComplianceCheck() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			// Defaults to the requesting User's ID if not specified.
 			"created_by_user_id": {
 				Type:     schema.TypeInt,
-				Required: true,
+				Optional: true,
 				ForceNew: true, // Not allowed to be changed, forces new item if changed.
 			},
 			"ct_managed": {

--- a/docs/resources/compliance_check.md
+++ b/docs/resources/compliance_check.md
@@ -31,12 +31,12 @@ description: |-
 
     3 - Azure Policy. These checks are scraped from Azure's policy reporting engine and apply Azure Policies to accounts.
 
-- **created_by_user_id** (Number) The user who created the Compliance Check.
 - **name** (String) Name of the Compliance Check.
 
 ### Optional
 
 - **azure_policy_id** (Number) The ID of the Azure Policy that this compliance check represents. Only present for Azure Policy compliance checks.
+- **created_by_user_id** (Number) The user who created the Compliance Check. Defaults to the requesting user if no value is provided.
 - **body** (String) Body of the Compliance Check defining what actions will be run.
 - **description** (String) Description for the Compliance Check.
 - **frequency_minutes** (Number) How often the check will be run, based on the specified frequency type below.


### PR DESCRIPTION
Creating a Compliance Check should no longer require the `created_by_user_id` field. This field now defaults to the requesting user's ID if not specified.